### PR TITLE
initial version of CAN driver diagnostic session messages

### DIFF
--- a/src/uds-driver-can/main.py
+++ b/src/uds-driver-can/main.py
@@ -1,0 +1,26 @@
+import uds_can
+import serialComm
+
+com_port = 'COM3'
+serial_baud_rate = 115200
+serial_timeout = 1
+
+if __name__ == "__main__":
+  esp32 = serialComm.serialCommTester(com_port,serial_baud_rate,serial_timeout)
+  newUDSTester = uds_can.UDSRequester(esp32,selfid=1,targetid=2)
+
+  newUDSTester.sendDefaultSession()
+  resp = newUDSTester.tester.recv()
+  print(f"{resp}")
+
+  newUDSTester.sendProgrammingSession()
+  resp = newUDSTester.tester.recv()
+  print(f"{resp}")
+
+  newUDSTester.sendExtendedSession()
+  resp = newUDSTester.tester.recv()
+  print(f"{resp}")
+
+  newUDSTester.sendSafetySystemDiagnosticSession()
+  resp = newUDSTester.tester.recv()
+  print(f"{resp}")

--- a/src/uds-driver-can/main.py
+++ b/src/uds-driver-can/main.py
@@ -24,3 +24,10 @@ if __name__ == "__main__":
   newUDSTester.sendSafetySystemDiagnosticSession()
   resp = newUDSTester.tester.recv()
   print(f"{resp}")
+  
+  newUDSTester.sendCodeClear()
+  resp = newUDSTester.tester.recv()
+  print(f"{resp}")
+
+  resp = newUDSTester.CodeClearProtocol()
+  print(f"{resp}")

--- a/src/uds-driver-can/main.py
+++ b/src/uds-driver-can/main.py
@@ -1,33 +1,58 @@
 import uds_can
 import serialComm
 
-com_port = 'COM3'
+com_port = "COM3"
 serial_baud_rate = 115200
 serial_timeout = 1
 
 if __name__ == "__main__":
-  esp32 = serialComm.serialCommTester(com_port,serial_baud_rate,serial_timeout)
-  newUDSTester = uds_can.UDSRequester(esp32,selfid=1,targetid=2)
+    esp32 = serialComm.serialCommTester(com_port, serial_baud_rate, serial_timeout)
+    newUDSTester = uds_can.UDSRequester(esp32, selfid=1, targetid=2)
 
-  newUDSTester.sendDefaultSession()
-  resp = newUDSTester.tester.recv()
-  print(f"{resp}")
+    # newUDSTester.sendSession(1)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
 
-  newUDSTester.sendProgrammingSession()
-  resp = newUDSTester.tester.recv()
-  print(f"{resp}")
+    # newUDSTester.sendSession(2)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
 
-  newUDSTester.sendExtendedSession()
-  resp = newUDSTester.tester.recv()
-  print(f"{resp}")
+    # newUDSTester.sendSession(3)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
 
-  newUDSTester.sendSafetySystemDiagnosticSession()
-  resp = newUDSTester.tester.recv()
-  print(f"{resp}")
-  
-  newUDSTester.sendCodeClear()
-  resp = newUDSTester.tester.recv()
-  print(f"{resp}")
+    # newUDSTester.sendSession(4)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
 
-  resp = newUDSTester.CodeClearProtocol()
-  print(f"{resp}")
+    # newUDSTester.sendCodeClear()
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
+
+    # newUDSTester.sendECUReset(1)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
+
+    # newUDSTester.sendECUReset(2)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
+
+    # newUDSTester.sendECUReset(3)
+    # resp = newUDSTester.tester.recv()
+    # print(f"{resp}")
+
+    # resp = newUDSTester.CodeClearProtocol()
+    # print(f"{resp}")
+
+    # resp = newUDSTester.ECUResetProtocol(1)
+    # print(f"{resp}")
+
+    # resp = newUDSTester.ECUResetProtocol(2)
+    # print(f"{resp}")
+
+    # resp = newUDSTester.ECUResetProtocol(3)
+    # print(f"{resp}")
+
+    newUDSTester.sendCustomFrame(input())
+    resp = newUDSTester.tester.recv()
+    print(f"{resp}")

--- a/src/uds-driver-can/serialComm.py
+++ b/src/uds-driver-can/serialComm.py
@@ -1,0 +1,29 @@
+import serial
+import time
+
+
+
+class serialCommTester:
+  def __init__(self,port, baudrate=115200, timeout=1):
+    serialComm = serial.Serial(port, baudrate, timeout=timeout,dsrdtr=False,rtscts=False)
+    serialComm.setRTS(False)
+    serialComm.setDTR(False)
+    self.serialComm = serialComm
+    # clear the serial buffer in case initializing the connection resets the connected board & it begins to write to the serial connection
+    resp = ''
+    while resp != 'timeout':
+      resp = self.recv()
+      print(resp)
+
+  def send(self,byteArray):
+    self.serialComm.write(byteArray)
+
+  def recv(self):
+    timeout = 1000
+    # wait until their are bytes available, use timeout to break and avoid infinite loop
+    while self.serialComm.in_waiting <= 0:
+      timeout = timeout - 1
+      if timeout == 0:
+        return "timeout"
+      time.sleep(.001)
+    return self.serialComm.readline().decode('ascii')

--- a/src/uds-driver-can/serialComm.py
+++ b/src/uds-driver-can/serialComm.py
@@ -20,7 +20,7 @@ class serialCommTester:
 
   def recv(self):
     timeout = 1000
-    # wait until their are bytes available, use timeout to break and avoid infinite loop
+    # wait until their are bytes available, use timeout to break and avoid infinite loop and
     while self.serialComm.in_waiting <= 0:
       timeout = timeout - 1
       if timeout == 0:

--- a/src/uds-driver-can/serialComm.py
+++ b/src/uds-driver-can/serialComm.py
@@ -2,28 +2,32 @@ import serial
 import time
 
 
-
 class serialCommTester:
-  def __init__(self,port, baudrate=115200, timeout=1):
-    serialComm = serial.Serial(port, baudrate, timeout=timeout,dsrdtr=False,rtscts=False)
-    serialComm.setRTS(False)
-    serialComm.setDTR(False)
-    self.serialComm = serialComm
-    # clear the serial buffer in case initializing the connection resets the connected board & it begins to write to the serial connection
-    resp = ''
-    while resp != 'timeout':
-      resp = self.recv()
-      print(resp)
+    def __init__(self, port, baudrate=115200, timeout=1):
+        serialComm = serial.Serial(
+            port, baudrate, timeout=timeout, dsrdtr=False, rtscts=False
+        )
+        serialComm.setRTS(False)
+        serialComm.setDTR(False)
+        self.serialComm = serialComm
+        # clear the serial buffer in case initializing the connection resets the connected board & it begins to write to the serial connection
+        resp = ""
+        while resp != "timeout":
+            resp = self.recv()
+            print(resp)
 
-  def send(self,byteArray):
-    self.serialComm.write(byteArray)
+    def send(self, header, data):
+        print(header)
+        print(data)
+        byteArray = [header] + data
+        self.serialComm.write(byteArray)
 
-  def recv(self):
-    timeout = 1000
-    # wait until their are bytes available, use timeout to break and avoid infinite loop and
-    while self.serialComm.in_waiting <= 0:
-      timeout = timeout - 1
-      if timeout == 0:
-        return "timeout"
-      time.sleep(.001)
-    return self.serialComm.readline().decode('ascii')
+    def recv(self):
+        timeout = 1000
+        # wait until their are bytes available, use timeout to break and avoid infinite loop and
+        while self.serialComm.in_waiting <= 0:
+            timeout = timeout - 1
+            if timeout == 0:
+                return "timeout"
+            time.sleep(0.001)
+        return self.serialComm.readline().decode("ascii")

--- a/src/uds-driver-can/uds_can.py
+++ b/src/uds-driver-can/uds_can.py
@@ -1,29 +1,5 @@
-class CANMessage:
-  """
-    Brief description of the class.
-
-    Attributes:
-        attribute1 (type): Description of attribute1.
-        attribute2 (type): Description of attribute2.
-  """
-  def __init__(self,id=0x0,data=[0x00,0x00,0x00,0x00]):
-    """
-    Initializes the ClassName with the given attributes.
-
-    Args:
-        attribute1 (type): Description of attribute1.
-        attribute2 (type): Description of attribute2.
-    """
-    self.id = id
-    self.data = data
-    self.length = len(data)
-  def convertToByteArray(self):
-    header = [self.id]
-    bytearray = header + self.data
-    return bytearray
-
 class UDSRequester:
-  """
+    """
     Brief description of the class.
 
     Attributes:
@@ -37,143 +13,188 @@ class UDSRequester:
       CodeClear CANMessage: Description of attribute2.
       PositiveCodeClearResponse CANMessage: Description of attribute2.
       NegativeCodeClearResponse CANMessage: Description of attribute2.
-  """
-  def __init__(self,tester,selfid=0x0,targetid=0x0):
     """
-    Initializes the ClassName with the given attributes.
 
-    Args:
-    
-    """
-    self.tester=tester
+    def __init__(self, tester, selfid=0x0, targetid=0x0):
+        """
+        Initializes the ClassName with the given attributes.
 
-    self.DefaultSession = CANMessage(targetid,[0x10,0x01])
-    self.ProgrammingSession = CANMessage(targetid,[0x10,0x02])
-    self.ExtendedSession = CANMessage(targetid,[0x10,0x03])
-    self.SafetySystemDiagnosticSession = CANMessage(targetid,[0x10,0x04])
-    self.PositiveSessionResponse = CANMessage(selfid,[0x50,0x03])
-    self.NegativeSessionResponse = CANMessage(selfid,[0x7F,0x10])
+        Args:
 
-    self.CodeClear = CANMessage(targetid,[0x14,0xFF,0xFF,0xFF])
-    self.PositiveCodeClearResponse = CANMessage(selfid,[0x54])
-    self.NegativeCodeClearResponse = CANMessage(selfid,[0x7F,0x14])
+        """
+        self.tester = tester
+        self.selfid = selfid
+        self.targetid = targetid
 
-    self.receivedResponse = ''
+        self.DefaultSession = [0x10, 0x01]
+        self.ProgrammingSession = [0x10, 0x02]
+        self.ExtendedSession = [0x10, 0x03]
+        self.SafetySystemDiagnosticSession = [0x10, 0x04]
+        self.PositiveSessionResponse = [0x50, 0x03]
+        self.NegativeSessionResponse = [0x7F, 0x10]
 
-  def receiveResponse(self):
-    resp = self.tester.recv()
-    self.receivedResponse = resp
-    return resp
+        self.CodeClear = [0x14]
+        self.PositiveCodeClearResponse = [0x54]
+        self.NegativeCodeClearResponse = [0x7F, 0x14]
 
-  def sendDefaultSession(self):
-    """
-    Displays the information of the example.
+        self.ECUReset_Hard = [0x11, 0x01]
+        self.ECUReset_KeyOffOn = [0x11, 0x02]
+        self.ECUReset_Soft = [0x11, 0x03]
+        self.PositiveECUResetResponse_Hard = [0x51, 0x01]
+        self.PositiveECUResetResponse_KeyOffOn = [0x51, 0x02]
+        self.PositiveECUResetResponse_Soft = [0x51, 0x03]
+        self.NegativeCodeClearResponse = [0x7F, 0x11]
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    self.tester.send(self.DefaultSession.convertToByteArray())
-    return
-  def sendProgrammingSession(self):
-    """
-    Displays the information of the example.
+        self.receivedResponse = ""
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    self.tester.send(self.ProgrammingSession.convertToByteArray())
-    return
-  def sendExtendedSession(self):
-    """
-    Displays the information of the example.
+    def updatetargetid(self, newTargetid):
+        self.targetid = newTargetid
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    self.tester.send(self.ExtendedSession.convertToByteArray())
-    return
-  def sendSafetySystemDiagnosticSession(self):
-    """
-    Displays the information of the example.
+    def receiveResponse(self):
+        resp = self.tester.recv()
+        self.receivedResponse = resp
+        return resp
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    self.tester.send(self.SafetySystemDiagnosticSession.convertToByteArray())
-    return
-  def checkPositiveSessionResponse(self,sessionType):
-    """
-    Displays the information of the example.
+    def sendCustomFrame(self, frameData):
+        data = list(bytearray.fromhex(frameData.replace(" ", "")))
+        self.tester.send(self.targetid, data)
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    resp = self.receiveResponse()
-    splitResp = resp.strip().lower().split(' ')
-    if (splitResp[1] == '50') and (sessionType == splitResp[2]):
-      return True
-    return False
-  def checkNegativeSessionResponse(self):
-    """
-    Displays the information of the example.
+    def sendSession(self, sessionType):
+        """
+        Displays the information of the example.
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    resp = self.receiveResponse()
-    splitResp = resp.strip().lower().split(' ')
-    if (splitResp[1] == '7f') and (splitResp[1] == '10'):
-      return True
-    return False
-  
-  def sendCodeClear(self):
-    """
-    Displays the information of the example.
+        Returns:
+            str: A string containing the name and value.
+        """
+        if sessionType == 1:
+            self.tester.send(self.targetid, self.DefaultSession)
+        elif sessionType == 2:
+            self.tester.send(self.targetid, self.ProgrammingSession)
+        elif sessionType == 3:
+            self.tester.send(self.targetid, self.ExtendedSession)
+        elif sessionType == 4:
+            self.tester.send(self.targetid, self.SafetySystemDiagnosticSession)
+        return
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    self.tester.send(self.CodeClear.convertToByteArray())
-    return
-  def checkPositiveCodeClearResponse(self):
-    """
-    Displays the information of the example.
+    def checkPositiveSessionResponse(self, sessionType):
+        """
+        Displays the information of the example.
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    resp = self.receiveResponse()
-    splitResp = resp.strip().lower().split(' ')
-    if splitResp[1] == '54':
-      return True
-    return False
-  def checkNegativeCodeClearResponse(self):
-    """
-    Displays the information of the example.
+        Returns:
+            str: A string containing the name and value.
+        """
+        resp = self.receiveResponse()
+        splitResp = resp.strip().lower().split(" ")
+        if (splitResp[1] == "50") and (sessionType == splitResp[2]):
+            return True
+        return False
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    resp = self.receiveResponse()
-    splitResp = resp.strip().lower().split(' ')
-    if splitResp[1] == '7f' and (splitResp[1] == '14'):
-      return True
-    return False
+    def checkNegativeSessionResponse(self):
+        """
+        Displays the information of the example.
 
-  def CodeClearProtocol(self):
-    """
-    Displays the information of the example.
+        Returns:
+            str: A string containing the name and value.
+        """
+        resp = self.receiveResponse()
+        splitResp = resp.strip().lower().split(" ")
+        if (splitResp[1] == "7f") and (splitResp[1] == "10"):
+            return True
+        return False
 
-    Returns:
-        str: A string containing the name and value.
-    """
-    self.sendExtendedSession()
-    if(self.checkPositiveSessionResponse('3') == False):
-      return self.receivedResponse
+    def sendCodeClear(self):
+        """
+        Displays the information of the example.
 
-    self.sendCodeClear()
-    return self.receiveResponse()
-    
-#ECU Reset
-#request VID
-  
+        Returns:
+            str: A string containing the name and value.
+        """
+        self.tester.send(self.targetid, self.CodeClear)
+        return
+
+    def checkPositiveCodeClearResponse(self):
+        """
+        Displays the information of the example.
+
+        Returns:
+            str: A string containing the name and value.
+        """
+        resp = self.receiveResponse()
+        splitResp = resp.strip().lower().split(" ")
+        if splitResp[1] == "54":
+            return True
+        return False
+
+    def checkNegativeCodeClearResponse(self):
+        """
+        Displays the information of the example.
+
+        Returns:
+            str: A string containing the name and value.
+        """
+        resp = self.receiveResponse()
+        splitResp = resp.strip().lower().split(" ")
+        if splitResp[1] == "7f" and (splitResp[1] == "14"):
+            return True
+        return False
+
+    def sendECUReset(self, resetType):
+        if resetType == 1:
+            self.tester.send(self.targetid, self.ECUReset_Hard)
+        elif resetType == 2:
+            self.tester.send(self.targetid, self.ECUReset_KeyOffOn)
+        elif resetType == 3:
+            self.tester.send(self.targetid, self.ECUReset_Soft)
+        return
+
+    def checkPositiveECUResetResponse(self, resetType):
+        """
+        Displays the information of the example.
+
+        Returns:
+            str: A string containing the name and value.
+        """
+        resp = self.receiveResponse()
+        splitResp = resp.strip().lower().split(" ")
+        if (splitResp[1] == "51") and (resetType == splitResp[2]):
+            return True
+        return False
+
+    def checkNegativeECUResetResponse(self):
+        """
+        Displays the information of the example.
+
+        Returns:
+            str: A string containing the name and value.
+        """
+        resp = self.receiveResponse()
+        splitResp = resp.strip().lower().split(" ")
+        if splitResp[1] == "7f" and (splitResp[1] == "11"):
+            return True
+        return False
+
+    def CodeClearProtocol(self):
+        """
+        Displays the information of the example.
+
+        Returns:
+            str: A string containing the name and value.
+        """
+        self.sendSession(3)
+        if self.checkPositiveSessionResponse("3") == False:
+            return self.receivedResponse
+
+        self.sendCodeClear()
+        return self.receiveResponse()
+
+    def ECUResetProtocol(self, resetType):
+        self.sendSession(3)
+        if self.checkPositiveSessionResponse("3") == False:
+            return self.receivedResponse
+
+        self.sendECUReset(resetType)
+        return self.receiveResponse()
+
+
+# ECU Reset
+# request VID

--- a/src/uds-driver-can/uds_can.py
+++ b/src/uds-driver-can/uds_can.py
@@ -58,6 +58,13 @@ class UDSRequester:
     self.PositiveCodeClearResponse = CANMessage(selfid,[0x54])
     self.NegativeCodeClearResponse = CANMessage(selfid,[0x7F,0x14])
 
+    self.receivedResponse = ''
+
+  def receiveResponse(self):
+    resp = self.tester.recv()
+    self.receivedResponse = resp
+    return resp
+
   def sendDefaultSession(self):
     """
     Displays the information of the example.
@@ -94,13 +101,17 @@ class UDSRequester:
     """
     self.tester.send(self.SafetySystemDiagnosticSession.convertToByteArray())
     return
-  def checkPositiveSessionResponse(self):
+  def checkPositiveSessionResponse(self,sessionType):
     """
     Displays the information of the example.
 
     Returns:
         str: A string containing the name and value.
     """
+    resp = self.receiveResponse()
+    splitResp = resp.strip().lower().split(' ')
+    if (splitResp[1] == '50') and (sessionType == splitResp[2]):
+      return True
     return False
   def checkNegativeSessionResponse(self):
     """
@@ -109,6 +120,10 @@ class UDSRequester:
     Returns:
         str: A string containing the name and value.
     """
+    resp = self.receiveResponse()
+    splitResp = resp.strip().lower().split(' ')
+    if (splitResp[1] == '7f') and (splitResp[1] == '10'):
+      return True
     return False
   
   def sendCodeClear(self):
@@ -127,6 +142,10 @@ class UDSRequester:
     Returns:
         str: A string containing the name and value.
     """
+    resp = self.receiveResponse()
+    splitResp = resp.strip().lower().split(' ')
+    if splitResp[1] == '54':
+      return True
     return False
   def checkNegativeCodeClearResponse(self):
     """
@@ -135,6 +154,10 @@ class UDSRequester:
     Returns:
         str: A string containing the name and value.
     """
+    resp = self.receiveResponse()
+    splitResp = resp.strip().lower().split(' ')
+    if splitResp[1] == '7f' and (splitResp[1] == '14'):
+      return True
     return False
 
   def CodeClearProtocol(self):
@@ -145,10 +168,12 @@ class UDSRequester:
         str: A string containing the name and value.
     """
     self.sendExtendedSession()
-    if(self.checkPositiveSessionResponse() == False):
-      return -1
-    self.sendCodeClear()
-    if(self.checkPositiveCodeClearResponse() == False):
-      return -1
+    if(self.checkPositiveSessionResponse('3') == False):
+      return self.receivedResponse
 
+    self.sendCodeClear()
+    return self.receiveResponse()
+    
+#ECU Reset
+#request VID
   

--- a/src/uds-driver-can/uds_can.py
+++ b/src/uds-driver-can/uds_can.py
@@ -1,0 +1,154 @@
+class CANMessage:
+  """
+    Brief description of the class.
+
+    Attributes:
+        attribute1 (type): Description of attribute1.
+        attribute2 (type): Description of attribute2.
+  """
+  def __init__(self,id=0x0,data=[0x00,0x00,0x00,0x00]):
+    """
+    Initializes the ClassName with the given attributes.
+
+    Args:
+        attribute1 (type): Description of attribute1.
+        attribute2 (type): Description of attribute2.
+    """
+    self.id = id
+    self.data = data
+    self.length = len(data)
+  def convertToByteArray(self):
+    header = [self.id]
+    bytearray = header + self.data
+    return bytearray
+
+class UDSRequester:
+  """
+    Brief description of the class.
+
+    Attributes:
+      tester CommDevice: general object to transmit CAN message information to. Requires a wrapped "send" function
+      DefaultSession CANMessage: Description of attribute1.
+      ProgrammingSession CANMessage: Description of attribute2.
+      ExtendedSession CANMessage: Description of attribute2.
+      SafetySystemDiagnosticSession CANMessage: Description of attribute2.
+      PositiveSessionResponse CANMessage: Description of attribute2.
+      NegativeSessionResponse CANMessage: Description of attribute2.
+      CodeClear CANMessage: Description of attribute2.
+      PositiveCodeClearResponse CANMessage: Description of attribute2.
+      NegativeCodeClearResponse CANMessage: Description of attribute2.
+  """
+  def __init__(self,tester,selfid=0x0,targetid=0x0):
+    """
+    Initializes the ClassName with the given attributes.
+
+    Args:
+    
+    """
+    self.tester=tester
+
+    self.DefaultSession = CANMessage(targetid,[0x10,0x01])
+    self.ProgrammingSession = CANMessage(targetid,[0x10,0x02])
+    self.ExtendedSession = CANMessage(targetid,[0x10,0x03])
+    self.SafetySystemDiagnosticSession = CANMessage(targetid,[0x10,0x04])
+    self.PositiveSessionResponse = CANMessage(selfid,[0x50,0x03])
+    self.NegativeSessionResponse = CANMessage(selfid,[0x7F,0x10])
+
+    self.CodeClear = CANMessage(targetid,[0x14,0xFF,0xFF,0xFF])
+    self.PositiveCodeClearResponse = CANMessage(selfid,[0x54])
+    self.NegativeCodeClearResponse = CANMessage(selfid,[0x7F,0x14])
+
+  def sendDefaultSession(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    self.tester.send(self.DefaultSession.convertToByteArray())
+    return
+  def sendProgrammingSession(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    self.tester.send(self.ProgrammingSession.convertToByteArray())
+    return
+  def sendExtendedSession(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    self.tester.send(self.ExtendedSession.convertToByteArray())
+    return
+  def sendSafetySystemDiagnosticSession(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    self.tester.send(self.SafetySystemDiagnosticSession.convertToByteArray())
+    return
+  def checkPositiveSessionResponse(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    return False
+  def checkNegativeSessionResponse(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    return False
+  
+  def sendCodeClear(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    self.tester.send(self.CodeClear.convertToByteArray())
+    return
+  def checkPositiveCodeClearResponse(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    return False
+  def checkNegativeCodeClearResponse(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    return False
+
+  def CodeClearProtocol(self):
+    """
+    Displays the information of the example.
+
+    Returns:
+        str: A string containing the name and value.
+    """
+    self.sendExtendedSession()
+    if(self.checkPositiveSessionResponse() == False):
+      return -1
+    self.sendCodeClear()
+    if(self.checkPositiveCodeClearResponse() == False):
+      return -1
+
+  


### PR DESCRIPTION
initial version of CAN driver. uds_can current has the session CAN frames and code clear frame defined along with basic send functionality to convert frames to byte array and send using a desired comm method. serialComm is a basic serial setup that works with ESP32 that can send a byte array and receive from the ESP32. main combines the 2 scripts currently to test if the session CAN frames can be sent over serial to an ESP32 properly & receive any response from the ESP32